### PR TITLE
Feature implementation from commits a457109..a05aba7

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023-2024 by AI Bloks for LLMWare 
+   Copyright 2023-2025 by AI Bloks for LLMWare 
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 
-Copyright 2023 and 2024 by llmware
+Copyright 2023-2025 by llmware
 
 NOTICE - Overview
 

--- a/llmware/agents.py
+++ b/llmware/agents.py
@@ -1,5 +1,5 @@
 
-# Copyright 2023-2024 llmware
+# Copyright 2023-2025 llmware
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You

--- a/llmware/configs.py
+++ b/llmware/configs.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 llmware
+# Copyright 2023-2025 llmware
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You

--- a/llmware/exceptions.py
+++ b/llmware/exceptions.py
@@ -1,5 +1,5 @@
 
-# Copyright 2023-2024 llmware
+# Copyright 2023-2025 llmware
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You

--- a/llmware/gguf_configs.py
+++ b/llmware/gguf_configs.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 llmware
+# Copyright 2023-2025 llmware
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You

--- a/llmware/graph.py
+++ b/llmware/graph.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 llmware
+# Copyright 2023-2025 llmware
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You


### PR DESCRIPTION
# PR Summary

Add image inclusion option to document_lookup and update copyright years

## Overview

This PR updates the document_lookup method to support optional image inclusion in results and updates copyright years across multiple files from 2024 to 2025.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Enhancement  | Added optional parameter to include images in document_lookup results |
| Maintenance  | Updated copyright years across multiple files |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `retrieval.py`         | Added optional 'include_images' parameter to document_lookup method |
| `agents.py`            | Updated copyright year from 2024 to 2025 |
| `configs.py`           | Updated copyright year from 2023-2024 to 2023-2025 |
| `exceptions.py`        | Updated copyright year from 2023-2024 to 2023-2025 |
| `gguf_configs.py`      | Updated copyright year from 2023-2024 to 2023-2025 |
| `graph.py`             | Updated copyright year from 2023-2024 to 2023-2025 |